### PR TITLE
Throw error when negative amount given

### DIFF
--- a/methods.js
+++ b/methods.js
@@ -83,6 +83,9 @@ module.exports = {
   convertAmount: function convertAmount (amount) {
     if (typeof amount !== 'number' || isNaN(amount)) throw new Error('Given amount is not valid')
 
+    // Check if the given amount is negative and throw an exception if it is
+    if (amount < 0) throw new Error('Given amount is negative')
+
     // Check if the given amount is too big and throw an exception if it is
     if (amount > 999999.99) throw new Error('Given amount is too big')
 

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -49,7 +49,7 @@ test('determine version', function determineVersionTests (t) {
 })
 
 test('convert amounts', function convertAmountTests (t) {
-  t.plan(7)
+  t.plan(8)
 
   t.equal(methods.convertAmount(25.20), '00002520', 'With cents')
   t.equal(methods.convertAmount(200), '00020000', 'Integer')
@@ -59,6 +59,7 @@ test('convert amounts', function convertAmountTests (t) {
   t.throws(function () { methods.convertAmount('27.56') }, 'String')
   t.throws(function () { methods.convertAmount() }, 'No argument')
   t.throws(function () { methods.convertAmount(27.566) }, 'Too many decimals')
+  t.throws(function () { methods.convertAmount(-0.01) }, 'Negative value')
 })
 
 test('pad correctly', function padTests (t) {


### PR DESCRIPTION
If virtual bar code is created with negative amount, the bar code will
contain dash. Since negative amounts are not logical in any way,
this commit prevents creating bar code with them.

I noticed this when used the library for creating bar codes for
value added taxes, which can be negative.